### PR TITLE
Current thinBackup doesn't copy build artifacts from sub-folders.

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -284,7 +284,9 @@ public class HudsonBackup {
     if (plugin.isBackupBuildArchive()) {
       final File archiveSrcDir = new File(buildSrcDir, ARCHIVE_DIR_NAME);
       if (archiveSrcDir.isDirectory()) {
-        final IOFileFilter filter = FileFilterUtils.andFileFilter(FileFileFilter.FILE, getFileAgeDiffFilter());
+        final IOFileFilter filter = FileFilterUtils.orFileFilter(
+                FileFilterUtils.directoryFileFilter(), 
+                FileFilterUtils.andFileFilter(FileFileFilter.FILE, getFileAgeDiffFilter()));
         FileUtils.copyDirectory(archiveSrcDir, new File(buildDestDir, "archive"), filter);
       }
     }


### PR DESCRIPTION
This occurs in multi-module Maven projects with manual artifact archiving.

I have changed the filter to also include sub-folders for build artifacts.
