### PR TITLE
fix users directory backup regression

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -322,9 +322,8 @@ public class HudsonBackup {
     if (srcDirectory.exists() && srcDirectory.isDirectory()) {
       LOGGER.fine(String.format("Backing up %s...", folderName));
       final File destDirectory = new File(backupDirectory.getAbsolutePath(), folderName);
-      IOFileFilter filter = FileFilterUtils.and(
-          getFileAgeDiffFilter(),
-          getExcludedFilesFilter(),
+      IOFileFilter filter = FileFilterUtils.or(
+          FileFilterUtils.and(getFileAgeDiffFilter(), getExcludedFilesFilter()),
           DirectoryFileFilter.DIRECTORY);
       FileUtils.copyDirectory(srcDirectory, destDirectory, filter);
       LOGGER.fine(String.format("DONE backing up %s.", folderName));


### PR DESCRIPTION
commit e827e1d5f9139c8d11fc53f6dfae53fbe586de93 caused a regression that
stopped the users directory from being backed up.

Signed-off-by: Spencer Oliver spen@spen-soft.co.uk
