### PR TITLE
Add ability to backup Mulitbranch pipeline jobs and builds

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -57,6 +57,8 @@ public class HudsonBackup {
   public static final String BUILDS_DIR_NAME = "builds";
   public static final String CONFIGURATIONS_DIR_NAME = "configurations";
   public static final String PROMOTIONS_DIR_NAME = "promotions";
+  public static final String MULTIBRANCH_DIR_NAME = "branches";
+  public static final String INDEXING_DIR_NAME = "indexing";
   public static final String JOBS_DIR_NAME = "jobs";
   public static final String USERS_DIR_NAME = "users";
   public static final String ARCHIVE_DIR_NAME = "archive";
@@ -249,6 +251,15 @@ public class HudsonBackup {
         backupBuildsFor(promotionDirectory, promotionBackupDirectory);
       }
     }
+    if (isMultibranchJob(jobDirectory)) {
+      FileUtils.copyDirectory(new File(jobDirectory, HudsonBackup.INDEXING_DIR_NAME), new File(jobBackupDirectory, HudsonBackup.INDEXING_DIR_NAME));
+      List<File> configurations = findAllConfigurations(new File(jobDirectory, HudsonBackup.MULTIBRANCH_DIR_NAME));
+      for (File configurationDirectory : configurations) {
+        File configurationBackupDirectory = createBackupDirectory(jobBackupDirectory, jobDirectory, configurationDirectory);
+        backupJobConfigFor(configurationDirectory, configurationBackupDirectory);
+        backupBuildsFor(configurationDirectory, configurationBackupDirectory);
+      }
+    }    
   }
 
   private void backupPluginArchives() throws IOException {
@@ -329,7 +340,11 @@ public class HudsonBackup {
   private boolean isPromotedJob(File jobDirectory) {
     return new File(jobDirectory, PROMOTIONS_DIR_NAME).isDirectory();
   }
-  
+
+  private boolean isMultibranchJob(File jobDirectory) {
+    return new File(jobDirectory, MULTIBRANCH_DIR_NAME).isDirectory();
+  }
+
   private void backupJobConfigFor(final File jobDirectory, final File jobBackupDirectory) throws IOException {
     final IOFileFilter filter = FileFilterUtils.and(
       FileFilterUtils.or(

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/TestHelper.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/TestHelper.java
@@ -150,6 +150,33 @@ public class TestHelper {
     addBuildNumber(nextBuildnumber);
   }
   
+  public static void addSingleMultibranchResult(File job) throws IOException, InterruptedException  {
+    File configurations = new File(job, HudsonBackup.MULTIBRANCH_DIR_NAME);
+    configurations.mkdir();
+    File branch1 = new File(configurations, "master");
+    branch1.mkdir();
+    File branch2 = new File(configurations, "development");
+    branch2.mkdir();
+    
+    addNewBuildToJob(branch1);
+    addNewBuildToJob(branch2);
+    
+    new File(branch1, "config.xml").createNewFile();
+    File nextBuildnumber = new File(branch1, "nextBuildNumber");
+    nextBuildnumber.createNewFile();
+    addBuildNumber(nextBuildnumber);
+    
+    new File(branch2, "config.xml").createNewFile();
+    nextBuildnumber = new File(branch2, "nextBuildNumber");
+    nextBuildnumber.createNewFile();
+    addBuildNumber(nextBuildnumber);
+
+    File indexing = new File(job, HudsonBackup.INDEXING_DIR_NAME);
+    indexing.mkdir();
+    new File(indexing, "indexing.xml").createNewFile();
+    new File(indexing, "indexing.log").createNewFile();
+  }
+
   public static boolean containsStringEndingWith(final List<String> strings, final String pattern) {
     boolean contains = false;
 

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupMultibranchJob.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupMultibranchJob.java
@@ -1,0 +1,89 @@
+package org.jvnet.hudson.plugins.thinbackup.backup;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import hudson.model.ItemGroup;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.plugins.thinbackup.TestHelper;
+import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
+import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
+import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
+
+public class TestBackupMultibranchJob {
+  
+  private File backupDir;
+  private File jenkinsHome;
+
+  @Before
+  public void setup() throws IOException, InterruptedException {
+    File base = new File(System.getProperty("java.io.tmpdir"));
+    backupDir = TestHelper.createBackupFolder(base);
+
+    jenkinsHome = TestHelper.createBasicFolderStructure(base);
+    File jobDir = TestHelper.createJob(jenkinsHome, TestHelper.TEST_JOB_NAME);
+    TestHelper.addNewBuildToJob(jobDir);
+    
+    TestHelper.addSingleMultibranchResult(jobDir);
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    FileUtils.deleteDirectory(jenkinsHome);
+    FileUtils.deleteDirectory(backupDir);
+    FileUtils.deleteDirectory(new File(Utils.THINBACKUP_TMP_DIR));
+  }
+  
+  private ThinBackupPluginImpl createMockPlugin() {
+    final ThinBackupPluginImpl mockPlugin = mock(ThinBackupPluginImpl.class);
+
+    when(mockPlugin.getHudsonHome()).thenReturn(jenkinsHome);
+    when(mockPlugin.getFullBackupSchedule()).thenReturn("");
+    when(mockPlugin.getDiffBackupSchedule()).thenReturn("");
+    when(mockPlugin.getExpandedBackupPath()).thenReturn(backupDir.getAbsolutePath());
+    when(mockPlugin.getNrMaxStoredFull()).thenReturn(-1);
+    when(mockPlugin.isCleanupDiff()).thenReturn(false);
+    when(mockPlugin.isMoveOldBackupsToZipFile()).thenReturn(false);
+    when(mockPlugin.isBackupBuildResults()).thenReturn(true);
+    when(mockPlugin.isBackupBuildArchive()).thenReturn(false);
+    when(mockPlugin.isBackupNextBuildNumber()).thenReturn(false);
+    when(mockPlugin.getExcludedFilesRegex()).thenReturn("");
+
+    return mockPlugin;
+  }
+  
+  @Test
+  public void testFullBuildResultsBackup() throws IOException {
+    final ThinBackupPluginImpl mockPlugin = createMockPlugin();
+
+    new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mock(ItemGroup.class)).backup();
+    
+    String[] list = backupDir.list();
+    Assert.assertEquals(1, list.length);
+    final File backup = new File(backupDir, list[0]);
+    list = backup.list();
+    Assert.assertEquals(6, list.length);
+    
+    File jobBackup = new File(backup, "jobs/"+TestHelper.TEST_JOB_NAME);
+    
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.MULTIBRANCH_DIR_NAME).exists());
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.MULTIBRANCH_DIR_NAME+"/master").exists());
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.MULTIBRANCH_DIR_NAME+"/development").exists());
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.MULTIBRANCH_DIR_NAME+"/master/"+HudsonBackup.BUILDS_DIR_NAME+"/"+TestHelper.CONCRETE_BUILD_DIRECTORY_NAME +"/build.xml").exists());
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.MULTIBRANCH_DIR_NAME+"/development/"+HudsonBackup.BUILDS_DIR_NAME+"/"+TestHelper.CONCRETE_BUILD_DIRECTORY_NAME +"/build.xml").exists());
+
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.INDEXING_DIR_NAME).exists());
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.INDEXING_DIR_NAME+"/indexing.xml").exists());
+    Assert.assertTrue(new File(jobBackup, HudsonBackup.INDEXING_DIR_NAME+"/indexing.log").exists());
+
+  }
+
+}


### PR DESCRIPTION
Multibranch pipeline jobs have a unique structure in the jobs directory.  The job directory includes and indexing and branches directories.

This change adds the ability for those directories to be added to the backup.