### PR TITLE
bump findbugs-maven-plugin to 3.0.4 as 3.0.3 does not work with maven…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>3.0.4</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>


### PR DESCRIPTION
… 3.6.0+

Signed-off-by: Philipp Homann <homann.philipp@googlemail.com>