### PR TITLE
Check multibranch indexing dir exists

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -346,7 +346,8 @@ public class HudsonBackup {
   }
 
   private boolean isMultibranchJob(File jobDirectory) {
-    return new File(jobDirectory, MULTIBRANCH_DIR_NAME).isDirectory();
+    return (new File(jobDirectory, MULTIBRANCH_DIR_NAME).isDirectory() &&
+            new File(jobDirectory, INDEXING_DIR_NAME).isDirectory());
   }
 
   private void backupJobConfigFor(final File jobDirectory, final File jobBackupDirectory) throws IOException {


### PR DESCRIPTION
To know if a job is a multibranch job, we check for the existance of the
'branches' directory. There are rare cases where the 'branches'
directory may exist but the job is not multibranch. I.e. when manually
getting the 'Pipeline script from SCM'. In such case, the 'indexing' folder
won't exist.

As an extra safety, checking if a job is a multibranch one, now we will
check for the 'branches' and 'indexing' folders existance.