### PR TITLE
Stop setting `pluginFirstClassLoader`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,14 +126,6 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<configuration>
-					<pluginFirstClassLoader>true</pluginFirstClassLoader>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<executions>


### PR DESCRIPTION
See [`pluginFirstClassLoader` and its discontents](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#pluginfirstclassloader-and-its-discontents). `pluginFirstClassLoader` is explicitly _not_ recommended, and as far as I can tell it is not needed for this plugin. Simpler to just remove it and follow the status quo.