### PR TITLE
JENKINS-67479: Add test and fix for malicious job folder

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -224,7 +224,10 @@ public class HudsonBackup {
             File folderBackupDirectory = new File(jobsBackupDirectory, jobName);
             File folderJobsBackupDirectory = new File(folderBackupDirectory, JOBS_DIR_NAME);
             folderJobsBackupDirectory.mkdirs();
-            FileUtils.copyFile(new File(jobDirectory, CONFIG_XML), new File(folderBackupDirectory, CONFIG_XML));
+            File expectedConfigXml = new File(jobDirectory, CONFIG_XML);
+            if (expectedConfigXml.exists() && expectedConfigXml.isFile()) {
+              FileUtils.copyFile(new File(jobDirectory, CONFIG_XML), new File(folderBackupDirectory, CONFIG_XML));
+            }
             backupJobsDirectory(childJobsFolder, folderJobsBackupDirectory);
           } else {
             backupJob(jobDirectory, jobsBackupDirectory, jobName);

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/TestHelper.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/TestHelper.java
@@ -72,6 +72,25 @@ public class TestHelper {
     
     return testJob;
   }
+  
+  /**
+   * When deleting multibranch jobs / folders or removing them we saw leftover directories in the Jenkins
+   * filesystem. They do not contain a config.xml nor any other file. We simulate a structure like that here:
+   * <pre>JENKINS_HOME/jobs/jobName
+   * '- jobs</pre>
+   * @param jenkinsHome
+   * @param jobName
+   * @return
+   * @throws IOException
+   */
+  public static File createMaliciousMultiJob(File jenkinsHome, String jobName) throws IOException {
+	    final File emptyJobDir = new File(new File(jenkinsHome, HudsonBackup.JOBS_DIR_NAME), "empty");
+	    emptyJobDir.mkdirs();
+	    final File jobsDirectory = new File(emptyJobDir, HudsonBackup.JOBS_DIR_NAME);
+	    jobsDirectory.mkdir();
+	    
+	    return emptyJobDir;
+  }
 
   private static File createJobsFolderWithConfiguration(File jenkinsHome, String jobName) throws IOException, FileNotFoundException {
     final File testJob = new File(new File(jenkinsHome, HudsonBackup.JOBS_DIR_NAME), jobName);

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
@@ -61,6 +61,7 @@ public class TestHudsonBackup {
 
     jenkinsHome = TestHelper.createBasicFolderStructure(base);
     File jobDir = TestHelper.createJob(jenkinsHome, TestHelper.TEST_JOB_NAME);
+    TestHelper.createMaliciousMultiJob(jenkinsHome, "emptyJob");
     buildDir = TestHelper.addNewBuildToJob(jobDir);
   }
   


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

# Description
To fix [JENKINS-67479](https://issues.jenkins.io/browse/JENKINS-67479) it is necessary to make sure that a _config.xml_ file exists before it is getting copied over to the backup. While this is being done on multiple places in (https://github.com/jenkinsci/thin-backup-plugin/blob/master/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java) it is missing on  [line 227](https://github.com/jenkinsci/thin-backup-plugin/blob/master/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java#L227). The PR fixes this spot and also adds a specific file structure (that we've seen in our instance) to the test scenario.

Running the tests without the fix fails the build, which shows that the fix is necessary for a file system that shows this structure.

(Please ignore the issue key in the commit message, it stems from our internal ticket system)