### PR TITLE
fix: remove broken img references in page headers

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.jelly
@@ -22,8 +22,7 @@
         <st:include it="${app}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/${it.iconFileName}" alt=""/>
-                thinBackup Configuration
+                ThinBackup Configuration
             </h1>
 
             <f:form method="post" action="saveSettings">

--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/index.jelly
@@ -22,7 +22,6 @@
         <st:include it="${app}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/${it.iconFileName}" alt=""/>
                 ${it.displayName}
             </h1>
             

--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/restoreOptions.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/restoreOptions.jelly
@@ -22,7 +22,6 @@
         <st:include it="${app}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>
-                <img src="${imagesURL}/48x48/${it.iconFileName}" alt=""/>
                 Restore Configuration
             </h1>
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

This PR removes broken `img references` from page headers. Probably these images/icons where served by Jenkins Core a while back, but it seems like this doesn't work for quite a while.


Before: 
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/14169258/197353978-558c4c27-1f14-473c-93f6-664a2cf3fee1.png">

After:
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/14169258/197353993-75d7b520-0c1e-4041-8410-57ca7452e179.png">
