### PR TITLE
Add option to also backup `config-history` folder

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
@@ -141,6 +141,7 @@ public class ThinBackupMgmtLink extends ManagementLink {
       @QueryParameter("backupAdditionalFiles") final boolean backupAdditionalFiles,
       @QueryParameter("backupAdditionalFilesRegex") final String backupAdditionalFilesRegex,
       @QueryParameter("waitForIdle") final boolean waitForIdle,
+      @QueryParameter("backupConfigHistory") final boolean backupConfigHistory,
       @QueryParameter("forceQuietModeTimeout") final String forceQuietModeTimeout) throws IOException {
     Jenkins jenkins = Jenkins.getInstanceOrNull();
     if (jenkins == null) {
@@ -160,6 +161,7 @@ public class ThinBackupMgmtLink extends ManagementLink {
     plugin.setBackupBuildArchive(backupBuildArchive);
     plugin.setBackupBuildsToKeepOnly(backupBuildsToKeepOnly);
     plugin.setBackupUserContents(backupUserContents);
+    plugin.setBackupConfigHistory(backupConfigHistory);
     plugin.setBackupNextBuildNumber(backupNextBuildNumber);
     plugin.setBackupPluginArchives(backupPluginArchives);
     plugin.setBackupAdditionalFiles(backupAdditionalFiles);

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPluginImpl.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPluginImpl.java
@@ -54,6 +54,8 @@ public class ThinBackupPluginImpl extends Plugin {
   private boolean backupBuildArchive = false;
   private boolean backupPluginArchives = false;
   private boolean backupUserContents = false;
+
+  private boolean backupConfigHistory = false;
   private boolean backupAdditionalFiles = false;
   private String backupAdditionalFilesRegex = null;
   private boolean backupNextBuildNumber = false;
@@ -379,4 +381,11 @@ public class ThinBackupPluginImpl extends Plugin {
     }
   }
 
+  public boolean isBackupConfigHistory() {
+    return backupConfigHistory;
+  }
+
+  public void setBackupConfigHistory(boolean backupConfigHistory) {
+    this.backupConfigHistory = backupConfigHistory;
+  }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -63,6 +63,7 @@ public class HudsonBackup {
   public static final String JOBS_DIR_NAME = "jobs";
   public static final String USERS_DIR_NAME = "users";
   public static final String ARCHIVE_DIR_NAME = "archive";
+  public static final String CONFIG_HISTORY_DIR_NAME = "config-history";
   public static final String USERSCONTENTS_DIR_NAME = "userContent";
   public static final String NEXT_BUILD_NUMBER_FILE_NAME = "nextBuildNumber";
   public static final String PLUGINS_DIR_NAME = "plugins";
@@ -171,6 +172,10 @@ public class HudsonBackup {
 
     if (plugin.isBackupUserContents()) {
       backupRootFolder(USERSCONTENTS_DIR_NAME);
+    }
+
+    if (plugin.isBackupConfigHistory()) {
+      backupRootFolder(CONFIG_HISTORY_DIR_NAME);
     }
 
     if (plugin.isBackupPluginArchives()) {

--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.jelly
@@ -97,6 +97,12 @@
                         name="backupPluginArchives" >
                     </f:optionalBlock>
 
+                    <f:optionalBlock title="Backup 'config-history' folder"
+                        help="/plugin/thinBackup/help/help-backupConfigHistory.html"
+                        checked="${it.configuration.backupConfigHistory}"
+                        name="backupConfigHistory" >
+                    </f:optionalBlock>
+
                     <f:optionalBlock title="Backup additional files"
                         help="/plugin/thinBackup/help/help-backupAdditionalFiles.html"
                         checked="${it.configuration.backupAdditionalFiles}"

--- a/src/main/webapp/help/help-backupConfigHistory.html
+++ b/src/main/webapp/help/help-backupConfigHistory.html
@@ -1,0 +1,29 @@
+<!--
+  The MIT License
+ 
+  Copyright (c) 2022, Stefan Spieker
+ 
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+ 
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+ 
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<div>
+  <p>
+    If this option is enabled, the directory <em>config-history</em> will also be backed up.
+  </p>
+</div>


### PR DESCRIPTION
Add option to also backup `config-history` folder as requested in [JENKINS-64973](https://issues.jenkins.io/browse/JENKINS-64973)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
