### PR TITLE
Use ionicons-api version provided by bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,18 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.346.x</artifactId>
+				<version>1678.vc1feb_6a_3c0f1</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
@@ -108,7 +120,6 @@
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>ionicons-api</artifactId>
-			<version>31.v4757b_6987003</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
I'm not aware of any version conflict, but if there's one, a release would resolve it.

cc @jenkinsci/thin-backup-plugin-developers 