### PR TITLE
Fixed some deprecation warnings

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/DirectoriesZipper.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/DirectoriesZipper.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -28,7 +29,7 @@ public class DirectoriesZipper extends DirectoryWalker<Object> implements Closea
     if (!zipFile.createNewFile()) {
       LOGGER.log(Level.WARNING, "{0} already exists. Previous backup will be overridden.", zipFile.getName());
     }
-    zipStream = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(zipFile)));
+    zipStream = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(zipFile.toPath())));
     this.rootPath = zipFile.getParent();
   }
 

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -199,7 +199,7 @@ public class HudsonBackup {
   private void backupGlobalXmls() throws IOException {
     LOGGER.fine("Backing up global configuration files...");
 
-    IOFileFilter suffixFileFilter = FileFilterUtils.and(FileFileFilter.FILE,
+    IOFileFilter suffixFileFilter = FileFilterUtils.and(FileFileFilter.INSTANCE,
         FileFilterUtils.suffixFileFilter(XML_FILE_EXTENSION), getFileAgeDiffFilter(), getExcludedFilesFilter());
     FileUtils.copyDirectory(hudsonHome, backupDirectory, ExistsAndReadableFileFilter.wrapperFilter(suffixFileFilter));
 
@@ -292,7 +292,7 @@ public class HudsonBackup {
         FileFilterUtils.suffixFileFilter(JPI_FILE_EXTENSION + DISABLED_EXTENSION),
         FileFilterUtils.suffixFileFilter(HPI_FILE_EXTENSION + DISABLED_EXTENSION));
 
-    final IOFileFilter filter = FileFilterUtils.and(FileFileFilter.FILE,
+    final IOFileFilter filter = FileFilterUtils.and(FileFileFilter.INSTANCE,
         FileFilterUtils.or(pluginArchivesFilter, disabledPluginMarkersFilter));
 
     backupRootFolder(PLUGINS_DIR_NAME, filter);
@@ -420,7 +420,7 @@ public class HudsonBackup {
     if (source.isDirectory()) {
       final IOFileFilter changelogFilter = FileFilterUtils.and(DirectoryFileFilter.DIRECTORY,
           FileFilterUtils.nameFileFilter(CHANGELOG_HISTORY_PLUGIN_DIR_NAME));
-      final IOFileFilter fileFilter = FileFilterUtils.and(FileFileFilter.FILE, getFileAgeDiffFilter());
+      final IOFileFilter fileFilter = FileFilterUtils.and(FileFileFilter.INSTANCE, getFileAgeDiffFilter());
 
       IOFileFilter filter = FileFilterUtils.and(FileFilterUtils.or(changelogFilter, fileFilter),
           getExcludedFilesFilter(),
@@ -438,7 +438,7 @@ public class HudsonBackup {
       final File archiveSrcDir = new File(buildSrcDir, ARCHIVE_DIR_NAME);
       if (archiveSrcDir.isDirectory()) {
         final IOFileFilter filter = FileFilterUtils.or(FileFilterUtils.directoryFileFilter(),
-            FileFilterUtils.and(FileFileFilter.FILE, getFileAgeDiffFilter()));
+            FileFilterUtils.and(FileFileFilter.INSTANCE, getFileAgeDiffFilter()));
         FileUtils.copyDirectory(archiveSrcDir, new File(buildDestDir, ARCHIVE_DIR_NAME),
             ExistsAndReadableFileFilter.wrapperFilter(filter));
       }

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/restore/HudsonRestore.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/restore/HudsonRestore.java
@@ -140,7 +140,7 @@ public class HudsonRestore {
     IOFileFilter zippedBackupSetsFilter = FileFilterUtils.and(
         FileFilterUtils.prefixFileFilter(BackupSet.BACKUPSET_ZIPFILE_PREFIX),
         FileFilterUtils.suffixFileFilter(HudsonBackup.ZIP_FILE_EXTENSION),
-        FileFileFilter.FILE);
+        FileFileFilter.INSTANCE);
 
     final File[] candidates = new File(backupPath).listFiles((FileFilter) zippedBackupSetsFilter);
     if (candidates != null) {

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/utils/Utils.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/utils/Utils.java
@@ -214,7 +214,7 @@ public final class Utils {
     IOFileFilter zipFileFilter = FileFilterUtils.and(
         FileFilterUtils.prefixFileFilter(BackupSet.BACKUPSET_ZIPFILE_PREFIX),
         FileFilterUtils.suffixFileFilter(HudsonBackup.ZIP_FILE_EXTENSION),
-        FileFileFilter.FILE);
+        FileFileFilter.INSTANCE);
 
     final File[] existingZips = parentDir.listFiles((FilenameFilter) zipFileFilter);
     if (existingZips == null) {


### PR DESCRIPTION
Fixed some deprecation warnings:
* Replaced `FileFileFilter.FILE` with the singleton `FileFileFilter.INSTANCE`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
