### PR TITLE
Feat: support for disable force jenkins to quiet mode

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/utils/Utils.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/utils/Utils.java
@@ -95,9 +95,11 @@ public final class Utils {
   /**
    * Waits until all executors are idle and switch jenkins to quiet mode. If it takes to long that all executors are
    * idle because in the mean time other jobs are executed the timeout ensure that the quiet mode is forced.
+   * But if timeout is set to -1, it will never force jenkins to quiet mode.
    *
    * @param timeout
-   *          specifies when a quiet mode is forced. 0 = no timeout.
+   *          specifies when a quiet mode is forced. 
+   *          0 = no timeout; -1 = disable timer, never force jenkins to quiet mode.
    * @param unit
    *          specifies the time unit for the value of timeout.
    * @throws IOException ?
@@ -127,7 +129,7 @@ public final class Utils {
         Thread.currentThread().interrupt();
       }
 
-      if (!jenkins.isQuietingDown() && starttime + unit.toMillis(timeout) < System.currentTimeMillis()) {
+      if (timeout != -1 && !jenkins.isQuietingDown() && starttime + unit.toMillis(timeout) < System.currentTimeMillis()) {
         LOGGER.info("Force quiet mode for jenkins now and wait until all executors are idle.");
         jenkins.doQuietDown();
       }

--- a/src/main/webapp/help/help-forceQuietModeTimeout.html
+++ b/src/main/webapp/help/help-forceQuietModeTimeout.html
@@ -29,4 +29,7 @@
   <br/>
   However this value in minutes specifies when Jenkins gets forced to the 'Quiet Mode'.
  </p>
+ <p>
+  <strong>NOTE:</strong><br/>If set to -1, it will never force Jenkins to the 'Quiet Mode'.
+ </p>
 </div>

--- a/src/main/webapp/help/help-forceQuietModeTimeout_de.html
+++ b/src/main/webapp/help/help-forceQuietModeTimeout_de.html
@@ -29,4 +29,7 @@
   <br/>
   Der Wert in Minuten gibt an, wann Jenkins in den 'Quiet Mode' gezwungen wird.
  </p>
+ <p>
+  <strong>HINWEIS:</strong><br/>Wenn es auf -1 gesetzt ist, wird es Jenkins niemals in den 'Quiet Mode' zwingen.
+ </p>
 </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

**Description:**
Support users to set "Force Jenkins to quiet mode after specified minutes" to -1 to disable the "force quiet" timer.
Because there would be scenarios which have higher priority than backup and users under those specific scenarios don't want to force Jenkins to quiet mode absolutely.

Just like the "Max number of backup sets" property, default is -1, which means disable this feature.
