### PR TITLE
JENKINS-71587: Add option to prevent fast failing of backup process

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
@@ -142,7 +142,8 @@ public class ThinBackupMgmtLink extends ManagementLink {
       @QueryParameter("backupAdditionalFilesRegex") final String backupAdditionalFilesRegex,
       @QueryParameter("waitForIdle") final boolean waitForIdle,
       @QueryParameter("backupConfigHistory") final boolean backupConfigHistory,
-      @QueryParameter("forceQuietModeTimeout") final String forceQuietModeTimeout) throws IOException {
+      @QueryParameter("forceQuietModeTimeout") final String forceQuietModeTimeout,
+      @QueryParameter("backupConfigHistory") final boolean failFast) throws IOException {
     Jenkins jenkins = Jenkins.getInstanceOrNull();
     if (jenkins == null) {
       return;
@@ -168,6 +169,7 @@ public class ThinBackupMgmtLink extends ManagementLink {
     plugin.setBackupAdditionalFilesRegex(backupAdditionalFilesRegex);
     plugin.setWaitForIdle(waitForIdle);
     plugin.setForceQuietModeTimeout(Integer.parseInt(forceQuietModeTimeout));
+    plugin.setFailFast(failFast);
     plugin.save();
     LOGGER.finest("Saving backup settings done.");
     rsp.sendRedirect(res.getContextPath() + THIN_BACKUP_SUBPATH);

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
@@ -143,7 +143,7 @@ public class ThinBackupMgmtLink extends ManagementLink {
       @QueryParameter("waitForIdle") final boolean waitForIdle,
       @QueryParameter("backupConfigHistory") final boolean backupConfigHistory,
       @QueryParameter("forceQuietModeTimeout") final String forceQuietModeTimeout,
-      @QueryParameter("backupConfigHistory") final boolean failFast) throws IOException {
+      @QueryParameter("failFast") final boolean failFast) throws IOException {
     Jenkins jenkins = Jenkins.getInstanceOrNull();
     if (jenkins == null) {
       return;

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPeriodicWork.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPeriodicWork.java
@@ -88,6 +88,7 @@ public class ThinBackupPeriodicWork extends AsyncPeriodicWork {
         }
 
         new HudsonBackup(plugin, type).backup();
+        LOGGER.info("Backup process finished successfully.");
       } else {
         LOGGER.warning("ThinBackup is not configured yet: No backup path set.");
       }
@@ -101,7 +102,7 @@ public class ThinBackupPeriodicWork extends AsyncPeriodicWork {
       if (!inQuietModeBeforeBackup) {
         jenkins.doCancelQuietDown();
       } else {
-        LOGGER.info("Backup process finished, but still in quiet mode as before. The quiet mode needs to be canceled manually, because it is not clear who is putting Jenkins into quiet mode.");
+        LOGGER.warning("Still in quiet mode as before. The quiet mode needs to be canceled manually, because it is not clear who is putting Jenkins into quiet mode.");
       }
     }
   }

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPluginImpl.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPluginImpl.java
@@ -60,6 +60,7 @@ public class ThinBackupPluginImpl extends Plugin {
   private String backupAdditionalFilesRegex = null;
   private boolean backupNextBuildNumber = false;
   private boolean backupBuildsToKeepOnly = false;
+  private boolean failFast = true;
 
   @Override
   public void start() throws Exception {
@@ -390,5 +391,15 @@ public class ThinBackupPluginImpl extends Plugin {
 
   public void setBackupConfigHistory(boolean backupConfigHistory) {
     this.backupConfigHistory = backupConfigHistory;
+  }
+
+  public boolean isFailFast()
+  {
+    return failFast;
+  }
+
+  public void setFailFast(boolean failFast)
+  {
+    this.failFast = failFast;
   }
 }

--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.jelly
@@ -122,6 +122,11 @@
                         help="/plugin/thinBackup/help/help-moveOldBackupsToZipFile.html"
                         checked="${it.configuration.moveOldBackupsToZipFile}"
                         name="moveOldBackupsToZipFile" />
+                    
+                    <f:optionalBlock title="${%fail_fast}"
+                        help="/plugin/thinBackup/help/help-failFast.html"
+                        checked="${it.configuration.failFast}"
+                        name="failFast" />
                 </f:section>
                 
                 <f:section>

--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings.properties
@@ -19,3 +19,4 @@ move = Move old backups to ZIP files
 save = Save
 thin_backup_configuration=ThinBackup Configuration
 wait_for_idle = Wait until Jenkins is idle to perform a backup
+fail_fast = Stop the backup as soon as an exception occurs in the file handling

--- a/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings_de.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink/backupsettings_de.properties
@@ -19,3 +19,4 @@ move = Alte Backups in ZIP Dateien verschieben
 save = Speichern
 thin_backup_configuration = ThinBackup Konfiguration
 wait_for_idle = Warte bis Jenkins idle ist um ein Backup durchzuführen
+fail_fast = Stoppe das Backup sobald eine Exception in der Behandlung der Dateien auftritt

--- a/src/main/webapp/help/help-failFast.html
+++ b/src/main/webapp/help/help-failFast.html
@@ -1,0 +1,30 @@
+<!--
+  The MIT License
+ 
+  Copyright (c) 2023, Stefan Spieker
+ 
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+ 
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+ 
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<div>
+  <p>
+    If this is checked, then whenever the backup process runs into an exception in the course of handling files, it will stop processing any other data.<br/>
+    (default behaviour: true)
+  </p>
+</div>

--- a/src/main/webapp/help/help-failFast_de.html
+++ b/src/main/webapp/help/help-failFast_de.html
@@ -1,0 +1,31 @@
+<!--
+  The MIT License
+ 
+  Copyright (c) 2023, Stefan Spieker
+ 
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+ 
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+ 
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<div>
+  <p>
+    Wenn diese Option gewählt ist, schlägt das Backup fehl, sobald eine Exception im Verlauf des Kopierens von Daten geworfen wird.<br/>
+    Es werden dann auch keine Folgeaufgaben (wie beispielsweise das Entfernen alter Backups) durchgeführt.<br/> 
+    (Standard: true)
+  </p>
+</div>


### PR DESCRIPTION
Description see https://issues.jenkins.io/browse/JENKINS-71587
The changes add a new configuration option which is set to true by default: The option allows to configure if the plugin fails fast when running into an exception in the process of backing up files from the Jenkins data.

### Testing done

Build locally with "mvn clean package". Was not capable to write a fitting unit test as the implementation is quite complex.
Tested the logic with a local Jenkins instance:
- left ThinBackup settings with default (thus it fails fast when it runs into an exception in the backup process)
- then ran a backup while having a file within the data which is not accessible to the jenkins user
- the plugin stops with an IOException (as expected)
- changed the setting to use the new option and prevent fast failing
- ran a backup again
- the plugin just logs the IOException and continues with the process and finishes successfully

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```