### PR TITLE
Migrate all tests to junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/BackupDirStructureSetup.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/BackupDirStructureSetup.java
@@ -1,19 +1,19 @@
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Calendar;
 
 import static org.jvnet.hudson.plugins.thinbackup.utils.Utils.getFormattedDirectory;
 
 public class BackupDirStructureSetup {
 
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder(new File(System.getProperty("java.io.tmpdir")));
+  @TempDir
+  Path tmpFolder;
 
   protected File backupDir;
 
@@ -31,9 +31,9 @@ public class BackupDirStructureSetup {
 
   protected File diff41;
 
-  @Before
-  public void setup() throws Exception {
-    backupDir = tmpFolder.newFolder("thin-backup");
+  @BeforeEach
+  public void setup() {
+    backupDir =  tmpFolder.toFile();
 
     final Calendar cal = Calendar.getInstance();
     cal.set(2011, Calendar.JANUARY, 1, 0, 0);

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupMatrixJob.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupMatrixJob.java
@@ -2,16 +2,17 @@ package org.jvnet.hudson.plugins.thinbackup.backup;
 
 import hudson.model.ItemGroup;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.plugins.thinbackup.TestHelper;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 
 import static org.mockito.Mockito.mock;
@@ -19,19 +20,20 @@ import static org.mockito.Mockito.when;
 
 public class TestBackupMatrixJob {
 
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
+  @TempDir
+  public Path tmpFolder;
 
   private File backupDir;
   private File jenkinsHome;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, InterruptedException {
-    backupDir = TestHelper.createBackupFolder(tmpFolder.newFolder("thin-backup"));
-    jenkinsHome = TestHelper.createBasicFolderStructure(tmpFolder.newFolder("jenkins"));
+    backupDir = TestHelper.createBackupFolder(Files.createDirectory(tmpFolder.resolve("thin-backup-matrix-job")).toFile());
+    jenkinsHome = TestHelper.createBasicFolderStructure(Files.createDirectory(tmpFolder.resolve("jenkins-matrix-job")).toFile());
+
     File jobDir = TestHelper.createJob(jenkinsHome, TestHelper.TEST_JOB_NAME);
     TestHelper.addNewBuildToJob(jobDir);
-    
+
     TestHelper.addSingleConfigurationResult(jobDir);
   }
   

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupMultibranchJob.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupMultibranchJob.java
@@ -1,23 +1,21 @@
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import hudson.model.ItemGroup;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Date;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.plugins.thinbackup.TestHelper;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestBackupMultibranchJob {
 

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupPromotedJob.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupPromotedJob.java
@@ -1,15 +1,6 @@
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import hudson.model.ItemGroup;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +9,15 @@ import org.jvnet.hudson.plugins.thinbackup.TestHelper;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
 import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestBackupPromotedJob {
   

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupSet.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupSet.java
@@ -16,56 +16,58 @@
  */
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 public class TestBackupSet extends BackupDirStructureSetup {
 
   @Test
   public void testSimpleBackupSet() {
     final BackupSet setFromFull = new BackupSet(full2);
-    Assert.assertTrue(setFromFull.isValid());
-    Assert.assertEquals(1, setFromFull.getDiffBackups().size());
-    Assert.assertEquals(full2, setFromFull.getFullBackup());
-    Assert.assertTrue(setFromFull.getDiffBackups().contains(diff21));
+    assertTrue(setFromFull.isValid());
+    assertEquals(1, setFromFull.getDiffBackups().size());
+    assertEquals(full2, setFromFull.getFullBackup());
+    assertTrue(setFromFull.getDiffBackups().contains(diff21));
 
     final BackupSet setFromDiff = new BackupSet(diff21);
-    Assert.assertTrue(setFromDiff.isValid());
-    Assert.assertEquals(1, setFromDiff.getDiffBackups().size());
-    Assert.assertEquals(full2, setFromDiff.getFullBackup());
-    Assert.assertTrue(setFromDiff.getDiffBackups().contains(diff21));
+    assertTrue(setFromDiff.isValid());
+    assertEquals(1, setFromDiff.getDiffBackups().size());
+    assertEquals(full2, setFromDiff.getFullBackup());
+    assertTrue(setFromDiff.getDiffBackups().contains(diff21));
   }
 
   @Test
   public void testDelete() throws Exception {
     final BackupSet setFromFull = new BackupSet(full1);
-    Assert.assertTrue(setFromFull.isValid());
-    Assert.assertEquals(4, setFromFull.getDiffBackups().size());
-    Assert.assertEquals(full1, setFromFull.getFullBackup());
-    Assert.assertTrue(setFromFull.getDiffBackups().contains(diff11));
-    Assert.assertTrue(setFromFull.getDiffBackups().contains(diff12));
-    Assert.assertTrue(setFromFull.getDiffBackups().contains(diff13));
-    Assert.assertTrue(setFromFull.getDiffBackups().contains(diff14));
+    assertTrue(setFromFull.isValid());
+    assertEquals(4, setFromFull.getDiffBackups().size());
+    assertEquals(full1, setFromFull.getFullBackup());
+    assertTrue(setFromFull.getDiffBackups().contains(diff11));
+    assertTrue(setFromFull.getDiffBackups().contains(diff12));
+    assertTrue(setFromFull.getDiffBackups().contains(diff13));
+    assertTrue(setFromFull.getDiffBackups().contains(diff14));
 
-    Assert.assertEquals(10, backupDir.list().length);
+    assertEquals(10, backupDir.list().length);
     setFromFull.delete();
-    Assert.assertEquals(5, backupDir.list().length);
+    assertEquals(5, backupDir.list().length);
   }
 
   @Test
   public void testInvalidSet() throws Exception {
     final BackupSet setFromDiff = new BackupSet(diff41);
-    Assert.assertFalse(setFromDiff.isValid());
-    Assert.assertFalse(setFromDiff.isValid());
-    Assert.assertNull(setFromDiff.getFullBackup());
-    Assert.assertNull(setFromDiff.getDiffBackups());
+    assertFalse(setFromDiff.isValid());
+    assertFalse(setFromDiff.isValid());
+    assertNull(setFromDiff.getFullBackup());
+    assertNull(setFromDiff.getDiffBackups());
 
-    Assert.assertEquals(10, backupDir.list().length);
+    assertEquals(10, backupDir.list().length);
     setFromDiff.delete();
-    Assert.assertEquals(10, backupDir.list().length);
+    assertEquals(10, backupDir.list().length);
   }
 
   @Test
@@ -74,38 +76,38 @@ public class TestBackupSet extends BackupDirStructureSetup {
     final BackupSet backupSet2 = new BackupSet(full2);
     final BackupSet invalidBackupSet = new BackupSet(diff41);
 
-    Assert.assertEquals(0, backupSet1.compareTo(backupSet1));
-    Assert.assertEquals(-1, backupSet1.compareTo(backupSet2));
-    Assert.assertEquals(1, backupSet2.compareTo(backupSet1));
-    Assert.assertEquals(1, backupSet1.compareTo(invalidBackupSet));
-    Assert.assertEquals(1, backupSet2.compareTo(invalidBackupSet));
-    Assert.assertEquals(-1, invalidBackupSet.compareTo(backupSet1));
+    assertEquals(0, backupSet1.compareTo(backupSet1));
+    assertEquals(-1, backupSet1.compareTo(backupSet2));
+    assertEquals(1, backupSet2.compareTo(backupSet1));
+    assertEquals(1, backupSet1.compareTo(invalidBackupSet));
+    assertEquals(1, backupSet2.compareTo(invalidBackupSet));
+    assertEquals(-1, invalidBackupSet.compareTo(backupSet1));
   }
 
   @Test
   public void testBackupSetContainsDirectory() throws IOException {
     final BackupSet backupSet1 = new BackupSet(full1);
 
-    Assert.assertTrue(backupSet1.containsDirectory(full1));
-    Assert.assertTrue(backupSet1.containsDirectory(new File(full1.getAbsolutePath())));
-    Assert.assertTrue(backupSet1.containsDirectory(diff11));
-    Assert.assertTrue(backupSet1.containsDirectory(diff12));
-    Assert.assertTrue(backupSet1.containsDirectory(diff13));
-    Assert.assertTrue(backupSet1.containsDirectory(diff14));
-    Assert.assertFalse(backupSet1.containsDirectory(null));
-    Assert.assertFalse(backupSet1.containsDirectory(full2));
-    Assert.assertFalse(backupSet1.containsDirectory(diff21));
-    Assert.assertFalse(backupSet1.containsDirectory(new File(diff21.getAbsolutePath())));
+    assertTrue(backupSet1.containsDirectory(full1));
+    assertTrue(backupSet1.containsDirectory(new File(full1.getAbsolutePath())));
+    assertTrue(backupSet1.containsDirectory(diff11));
+    assertTrue(backupSet1.containsDirectory(diff12));
+    assertTrue(backupSet1.containsDirectory(diff13));
+    assertTrue(backupSet1.containsDirectory(diff14));
+    assertFalse(backupSet1.containsDirectory(null));
+    assertFalse(backupSet1.containsDirectory(full2));
+    assertFalse(backupSet1.containsDirectory(diff21));
+    assertFalse(backupSet1.containsDirectory(new File(diff21.getAbsolutePath())));
 
     final BackupSet invalidBackupSet = new BackupSet(diff41);
-    Assert.assertFalse(invalidBackupSet.containsDirectory(diff41));
+    assertFalse(invalidBackupSet.containsDirectory(diff41));
 
     final File tempDir = new File(System.getProperty("java.io.tmpdir"));
     backupDir = new File(tempDir, "BackupDirForHudsonBackupTest");
-    final File testFile = tmpFolder.newFile("tempFile.nxt");
+    final File testFile = tmpFolder.resolve("tempFile.nxt").toFile();
     testFile.createNewFile();
-    Assert.assertFalse(backupSet1.containsDirectory(testFile));
-    Assert.assertFalse(backupSet1.containsDirectory(new File(testFile.getAbsolutePath())));
+    assertFalse(backupSet1.containsDirectory(testFile));
+    assertFalse(backupSet1.containsDirectory(new File(testFile.getAbsolutePath())));
   }
 
 }

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupWithCloudBeesFolder.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupWithCloudBeesFolder.java
@@ -1,13 +1,6 @@
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 import hudson.model.ItemGroup;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +10,13 @@ import org.jvnet.hudson.plugins.thinbackup.TestHelper;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
 import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class TestBackupWithCloudBeesFolder {
   private static final String TEST_FOLDER = "testFolder";

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupZipping.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupZipping.java
@@ -1,64 +1,60 @@
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.jvnet.hudson.plugins.thinbackup.TestHelper;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.jvnet.hudson.plugins.thinbackup.TestHelper;
-import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBackupZipping {
 
+  @TempDir
+  public Path tmpFolder;
   private File backupDir;
   private File jenkinsHome;
 
-  @Before
-  public void setup() throws IOException, InterruptedException {
-    File base = new File(System.getProperty("java.io.tmpdir"));
-    backupDir = TestHelper.createBackupFolder(base);
+  @BeforeEach
+  public void setup() throws IOException {
+    backupDir = TestHelper.createBackupFolder(Files.createDirectory(tmpFolder.resolve("thin-backup-zipping")).toFile());
+    jenkinsHome = TestHelper.createBasicFolderStructure(Files.createDirectory(tmpFolder.resolve("backup-zipping")).toFile());
 
-    jenkinsHome = TestHelper.createBasicFolderStructure(base);
     File jobDir = TestHelper.createJob(jenkinsHome, TestHelper.TEST_JOB_NAME);
     TestHelper.addNewBuildToJob(jobDir);
-    
   }
-  
-  @After
-  public void tearDown() throws Exception {
-    FileUtils.deleteDirectory(jenkinsHome);
-    FileUtils.deleteDirectory(backupDir);
-    FileUtils.deleteDirectory(new File(Utils.THINBACKUP_TMP_DIR));
-  }
+
   
   @Test
   public void testThinBackupZipper() throws Exception {
     // create a backed up structure with DIFF back ups
     final TestHudsonBackup tester = new TestHudsonBackup();
+    tester.backupDir = backupDir;
+    tester.jenkinsHome = jenkinsHome;
     tester.setup();
     tester.testHudsonDiffBackup();
 
     File[] files = backupDir.listFiles();
-    Assert.assertEquals(2, files.length);
+    assertEquals(2, files.length);
 
     final BackupSet backupSetFromDirectory = new BackupSet(files[0]);
-    Assert.assertTrue(backupSetFromDirectory.isValid());
-    Assert.assertFalse(backupSetFromDirectory.isInZipFile());
-    Assert.assertEquals(backupSetFromDirectory, backupSetFromDirectory.unzip());
+    assertTrue(backupSetFromDirectory.isValid());
+    assertFalse(backupSetFromDirectory.isInZipFile());
+    assertEquals(backupSetFromDirectory, backupSetFromDirectory.unzip());
 
     final File zippedBackupSet = backupSetFromDirectory.zipTo(backupDir);
-    Assert.assertNotNull(zippedBackupSet);
+    assertNotNull(zippedBackupSet);
 
     files = backupDir.listFiles();
-    Assert.assertEquals(3, files.length);
+    assertEquals(3, files.length);
 
     final ZipFile zipFile = new ZipFile(zippedBackupSet);
     final Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
@@ -67,42 +63,42 @@ public class TestBackupZipping {
       zipEntries.nextElement();
       ++entryCount;
     }
-    Assert.assertEquals(23, entryCount);
+    assertEquals(23, entryCount);
     zipFile.close();
 
     final BackupSet backupSetFromZip = new BackupSet(zippedBackupSet);
-    Assert.assertTrue(backupSetFromZip.isValid());
-    Assert.assertTrue(backupSetFromZip.isInZipFile());
+    assertTrue(backupSetFromZip.isValid());
+    assertTrue(backupSetFromZip.isInZipFile());
 
-    Assert.assertEquals(backupSetFromDirectory.getFullBackupName(), backupSetFromZip.getFullBackupName());
-    Assert.assertEquals(backupSetFromDirectory.getDiffBackupsNames().size(), backupSetFromZip.getDiffBackupsNames()
+    assertEquals(backupSetFromDirectory.getFullBackupName(), backupSetFromZip.getFullBackupName());
+    assertEquals(backupSetFromDirectory.getDiffBackupsNames().size(), backupSetFromZip.getDiffBackupsNames()
         .size());
 
     final BackupSet backupSetFromUnzippedZip = backupSetFromZip.unzip();
-    Assert.assertTrue(backupSetFromUnzippedZip.isValid());
-    Assert.assertFalse(backupSetFromUnzippedZip.isInZipFile());
-    Assert.assertNotNull(backupSetFromUnzippedZip.getFullBackup());
-    Assert.assertTrue(backupSetFromUnzippedZip.getFullBackup().exists());
-    Assert.assertNotNull(backupSetFromUnzippedZip.getDiffBackups());
+    assertTrue(backupSetFromUnzippedZip.isValid());
+    assertFalse(backupSetFromUnzippedZip.isInZipFile());
+    assertNotNull(backupSetFromUnzippedZip.getFullBackup());
+    assertTrue(backupSetFromUnzippedZip.getFullBackup().exists());
+    assertNotNull(backupSetFromUnzippedZip.getDiffBackups());
     for (final File diffBackup : backupSetFromUnzippedZip.getDiffBackups()) {
-      Assert.assertTrue(diffBackup.exists());
+      assertTrue(diffBackup.exists());
     }
 
     final File f1 = new File(backupSetFromUnzippedZip.getFullBackup(), "jobs");
     final File f2 = new File(f1, "test");
     final File configXml = new File(f2, "config.xml");
 
-    Assert.assertEquals(20, configXml.length());
+    assertEquals(20, configXml.length());
     final byte[] data = new byte[20];
     final BufferedInputStream bis = new BufferedInputStream(Files.newInputStream(configXml.toPath()));
     bis.read(data);
     bis.close();
     final String configXmlContents = new String(data);
-    Assert.assertEquals(TestHelper.CONFIG_XML_CONTENTS, configXmlContents);
+    assertEquals(TestHelper.CONFIG_XML_CONTENTS, configXmlContents);
 
     backupSetFromZip.deleteUnzipDir();
-    Assert.assertFalse(backupSetFromZip.getUnzipDir().exists());
-    Assert.assertFalse(backupSetFromUnzippedZip.getFullBackup().exists());
+    assertFalse(backupSetFromZip.getUnzipDir().exists());
+    assertFalse(backupSetFromUnzippedZip.getFullBackup().exists());
   }
 
 }

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
@@ -16,63 +16,59 @@
  */
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
 import hudson.model.ItemGroup;
 import hudson.model.TopLevelItem;
-import hudson.model.FreeStyleProject;
 import hudson.util.RunList;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.jvnet.hudson.plugins.thinbackup.TestHelper;
+import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
+import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
+import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.FileFilterUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.jvnet.hudson.plugins.thinbackup.TestHelper;
-import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
-import org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl;
-import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestHudsonBackup {
 
-  private File backupDir;
-  private File jenkinsHome;
+  @TempDir
+  File backupDir;
+  File jenkinsHome;
   private File buildDir;
   private ItemGroup<TopLevelItem> mockHudson;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InterruptedException {
     mockHudson = mock(ItemGroup.class);
     
     File base = new File(System.getProperty("java.io.tmpdir"));
-    backupDir = TestHelper.createBackupFolder(base);
 
     jenkinsHome = TestHelper.createBasicFolderStructure(base);
     File jobDir = TestHelper.createJob(jenkinsHome, TestHelper.TEST_JOB_NAME);
     TestHelper.createMaliciousMultiJob(jenkinsHome, "emptyJob");
     buildDir = TestHelper.addNewBuildToJob(jobDir);
   }
-  
-  @After
+
+  @AfterEach
   public void tearDown() throws Exception {
     FileUtils.deleteDirectory(jenkinsHome);
     FileUtils.deleteDirectory(backupDir);
@@ -86,29 +82,29 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     final List<String> arrayList = Arrays.asList(job.list());
-    Assert.assertEquals(2, arrayList.size());
-    Assert.assertFalse(arrayList.contains(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME));
+    assertEquals(2, arrayList.size());
+    assertFalse(arrayList.contains(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME));
 
     final File build = new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME);
     list = build.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(7, list.length);
+    assertNotNull(list);
+    assertEquals(7, list.length);
 
     final File changelogHistory = new File(
         new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME),
         HudsonBackup.CHANGELOG_HISTORY_PLUGIN_DIR_NAME);
     list = changelogHistory.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(2, list.length);
+    assertNotNull(list);
+    assertEquals(2, list.length);
   }  
 
   @Test
@@ -119,29 +115,29 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     list = job.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(2, list.length);
+    assertNotNull(list);
+    assertEquals(2, list.length);
 
     final File build = new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME);
     list = build.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File changelogHistory = new File(
         new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME),
         HudsonBackup.CHANGELOG_HISTORY_PLUGIN_DIR_NAME);
     list = changelogHistory.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(2, list.length);
+    assertNotNull(list);
+    assertEquals(2, list.length);
 
     boolean containsLogfile = false;
     for (final String string : list) {
@@ -150,7 +146,7 @@ public class TestHudsonBackup {
         break;
       }
     }
-    Assert.assertFalse(containsLogfile);
+    assertFalse(containsLogfile);
   }
 
   @Test
@@ -161,18 +157,18 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     list = job.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
-    Assert.assertEquals("config.xml", list[0]);
+    assertNotNull(list);
+    assertEquals(1, list.length);
+    assertEquals("config.xml", list[0]);
   }
 
   public void performHudsonDiffBackup(final ThinBackupPluginImpl mockPlugin) throws Exception {
@@ -200,7 +196,7 @@ public class TestHudsonBackup {
 
     final File lastDiffBackup = backupDir.listFiles((FileFilter) FileFilterUtils.prefixFileFilter(BackupType.DIFF
         .toString()))[0];
-    Assert.assertEquals(1, lastDiffBackup.list().length);
+    assertEquals(1, lastDiffBackup.list().length);
   }
 
   @Test
@@ -211,29 +207,29 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     final List<String> arrayList = Arrays.asList(job.list());
-    Assert.assertEquals(3, arrayList.size());
+    assertEquals(3, arrayList.size());
     assertThat(arrayList, hasItem(containsString(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME)));
 
     final File build = new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME);
     list = build.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(7, list.length);
+    assertNotNull(list);
+    assertEquals(7, list.length);
 
     final File changelogHistory = new File(
         new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME),
         HudsonBackup.CHANGELOG_HISTORY_PLUGIN_DIR_NAME);
     list = changelogHistory.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(2, list.length);
+    assertNotNull(list);
+    assertEquals(2, list.length);
   }
 
   @Test
@@ -244,28 +240,28 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     List<String> arrayList = Arrays.asList(job.list());
-    Assert.assertEquals(2, arrayList.size());
-    Assert.assertFalse(arrayList.contains(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME));
+    assertEquals(2, arrayList.size());
+    assertFalse(arrayList.contains(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME));
 
     final File build = new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME);
     arrayList = Arrays.asList(build.list());
-    Assert.assertEquals(8, arrayList.size());
+    assertEquals(8, arrayList.size());
 
     final File changelogHistory = new File(
         new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME),
         HudsonBackup.CHANGELOG_HISTORY_PLUGIN_DIR_NAME);
     list = changelogHistory.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(2, list.length);
+    assertNotNull(list);
+    assertEquals(2, list.length);
   }
 
   @Test
@@ -283,18 +279,18 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     list = job.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
-    Assert.assertEquals("config.xml", list[0]);    
+    assertNotNull(list);
+    assertEquals(1, list.length);
+    assertEquals("config.xml", list[0]);
   }  
   
   @Test
@@ -313,22 +309,22 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(Arrays.toString(list) ,1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(6, list.length);
+    assertNotNull(list);
+    assertEquals(6, list.length);
 
     final File job = new File(new File(backup, HudsonBackup.JOBS_DIR_NAME), TestHelper.TEST_JOB_NAME);
     final List<String> arrayList = Arrays.asList(job.list());
-    Assert.assertEquals(2, arrayList.size());
-    Assert.assertFalse(arrayList.contains(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME));
+    assertEquals(2, arrayList.size());
+    assertFalse(arrayList.contains(HudsonBackup.NEXT_BUILD_NUMBER_FILE_NAME));
 
     final File build = new File(new File(job, HudsonBackup.BUILDS_DIR_NAME), TestHelper.CONCRETE_BUILD_DIRECTORY_NAME);
     list = build.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(7, list.length);
+    assertNotNull(list);
+    assertEquals(7, list.length);
   }
   
   @Test
@@ -355,7 +351,7 @@ public class TestHudsonBackup {
     }
     final ThinBackupPluginImpl mockPlugin = TestHelper.createMockPlugin(jenkinsHome, backupDir);
 
-    Assert.assertEquals(filesAndFolders.toString(),72, filesAndFolders.size());
+    assertEquals(72, filesAndFolders.size());
     HudsonBackup backup = new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson);
     backup.removeEmptyDirs(jenkinsHome);
     try (Stream<Path> walk = Files.walk(jenkinsHome.toPath())) {
@@ -366,7 +362,7 @@ public class TestHudsonBackup {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    Assert.assertEquals(filesAndFolders.toString(),25, filesAndFolders.size());
+    assertEquals(25, filesAndFolders.size());
   }
   
   @Test
@@ -378,23 +374,23 @@ public class TestHudsonBackup {
     new HudsonBackup(mockPlugin, BackupType.FULL, new Date(), mockHudson).backup();
 
     String[] list = backupDir.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
+    assertNotNull(list);
+    assertEquals(1, list.length);
     final File backup = new File(backupDir, list[0]);
     list = backup.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(7, list.length);
+    assertNotNull(list);
+    assertEquals(7, list.length);
 
     final File nodes = new File(backup, HudsonBackup.NODES_DIR_NAME);
     list = nodes.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
-    Assert.assertEquals(TestHelper.TEST_NODE_NAME, list[0]);
+    assertNotNull(list);
+    assertEquals(1, list.length);
+    assertEquals(TestHelper.TEST_NODE_NAME, list[0]);
 
     final File node = new File(nodes, TestHelper.TEST_NODE_NAME);
     list = node.list();
-    Assert.assertNotNull(list);
-    Assert.assertEquals(1, list.length);
-    Assert.assertEquals(HudsonBackup.CONFIG_XML, list[0]);
+    assertNotNull(list);
+    assertEquals(1, list.length);
+    assertEquals(HudsonBackup.CONFIG_XML, list[0]);
   }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
@@ -51,8 +51,8 @@ import static org.mockito.Mockito.when;
 public class TestHudsonBackup {
 
   @TempDir
-  File backupDir;
-  File jenkinsHome;
+  public File backupDir;
+  public File jenkinsHome;
   private File buildDir;
   private ItemGroup<TopLevelItem> mockHudson;
 

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestPluginList.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestPluginList.java
@@ -16,13 +16,13 @@
  */
 package org.jvnet.hudson.plugins.thinbackup.backup;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/utils/TestUtils.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/utils/TestUtils.java
@@ -26,25 +26,27 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.plugins.thinbackup.ThinBackupPeriodicWork.BackupType;
 import org.jvnet.hudson.plugins.thinbackup.backup.BackupDirStructureSetup;
 import org.jvnet.hudson.plugins.thinbackup.backup.BackupSet;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestUtils extends BackupDirStructureSetup {
 
   private File tmpDir;
 
-  @Before
+  @BeforeEach
   public void init() {
     tmpDir = new File(System.getenv("tmp"), "test");
     tmpDir.mkdir();
   }
   
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     FileUtils.deleteDirectory(tmpDir);
   }
@@ -53,24 +55,28 @@ public class TestUtils extends BackupDirStructureSetup {
   public void testConvertToDirectoryNameDateFormat() throws ParseException {
     final String displayDate = "2011-02-13 10:48";
     final String fileDate = Utils.convertToDirectoryNameDateFormat(displayDate);
-    Assert.assertEquals("2011-02-13_10-48", fileDate);
+    assertEquals("2011-02-13_10-48", fileDate);
   }
 
-  @Test(expected = ParseException.class)
-  public void testBadFormatConvertToDirectoryNameDateFormat() throws ParseException {
-    final String displayDate = "2011-02-13-10:48";
-    Utils.convertToDirectoryNameDateFormat(displayDate);
+  @Test
+  public void testBadFormatConvertToDirectoryNameDateFormat() {
+    assertThrows(ParseException.class,
+            () -> Utils.convertToDirectoryNameDateFormat("2011-02-13-10:48")
+    );
   }
 
-  @Test(expected = ParseException.class)
-  public void testWrongFormatConvertToDirectoryNameDateFormat() throws ParseException {
-    final String displayDate = "FULL-2011-02-13_10-48";
-    Utils.convertToDirectoryNameDateFormat(displayDate);
+  @Test
+  public void testWrongFormatConvertToDirectoryNameDateFormat() {
+    assertThrows(ParseException.class,
+            () -> Utils.convertToDirectoryNameDateFormat("FULL-2011-02-13_10-48")
+    );
   }
 
-  @Test(expected = ParseException.class)
-  public void testEmptyDateConvertToDirectoryNameDateFormat() throws ParseException {
-    Utils.convertToDirectoryNameDateFormat("");
+  @Test
+  public void testEmptyDateConvertToDirectoryNameDateFormat() {
+    assertThrows(ParseException.class,
+            () -> Utils.convertToDirectoryNameDateFormat("")
+    );
   }
 
   @Test
@@ -82,75 +88,75 @@ public class TestUtils extends BackupDirStructureSetup {
 
     String displayDate = "FULL-2011-02-13_10-48";
     Date tmp = Utils.getDateFromBackupDirectoryName(displayDate);
-    Assert.assertNotNull(tmp);
-    Assert.assertEquals(expected, tmp);
+    assertNotNull(tmp);
+    assertEquals(expected, tmp);
 
     displayDate = "DIFF-2011-02-13_10-48";
     tmp = Utils.getDateFromBackupDirectoryName(displayDate);
-    Assert.assertNotNull(tmp);
-    Assert.assertEquals(expected, tmp);
+    assertNotNull(tmp);
+    assertEquals(expected, tmp);
   }
 
   @Test
   public void testGetDateFromInvalidBackupDir() {
     final String displayDate = "DWDWD-2011-02-13_10-48";
     final Date tmp = Utils.getDateFromBackupDirectoryName(displayDate);
-    Assert.assertNull(tmp);
+    assertNull(tmp);
   }
 
   @Test
   public void testGetBackupTypeDirectories() {
     final List<File> fullBackupDirs = Utils.getBackupTypeDirectories(backupDir, BackupType.FULL);
-    Assert.assertEquals(3, fullBackupDirs.size());
+    assertEquals(3, fullBackupDirs.size());
 
     final List<File> diffBackupDirs = Utils.getBackupTypeDirectories(backupDir, BackupType.DIFF);
-    Assert.assertEquals(7, diffBackupDirs.size());
+    assertEquals(7, diffBackupDirs.size());
   }
 
   @Test
   public void testGetReferencedFullBackup() {
     File fullBackup = Utils.getReferencedFullBackup(diff11);
-    Assert.assertEquals(full1, fullBackup);
+    assertEquals(full1, fullBackup);
 
     fullBackup = Utils.getReferencedFullBackup(diff12);
-    Assert.assertEquals(full1, fullBackup);
+    assertEquals(full1, fullBackup);
 
     fullBackup = Utils.getReferencedFullBackup(diff13);
-    Assert.assertEquals(full1, fullBackup);
+    assertEquals(full1, fullBackup);
 
     fullBackup = Utils.getReferencedFullBackup(diff14);
-    Assert.assertEquals(full1, fullBackup);
+    assertEquals(full1, fullBackup);
 
     fullBackup = Utils.getReferencedFullBackup(full1);
-    Assert.assertEquals(full1, fullBackup);
+    assertEquals(full1, fullBackup);
 
     fullBackup = Utils.getReferencedFullBackup(diff41);
-    Assert.assertNull(fullBackup);
+    assertNull(fullBackup);
   }
 
   @Test
   public void testGetReferencingDiffBackups() {
     List<File> diffBackups = Utils.getReferencingDiffBackups(full1);
-    Assert.assertEquals(4, diffBackups.size());
-    Assert.assertTrue(diffBackups.contains(diff11));
-    Assert.assertTrue(diffBackups.contains(diff12));
-    Assert.assertTrue(diffBackups.contains(diff13));
-    Assert.assertTrue(diffBackups.contains(diff14));
+    assertEquals(4, diffBackups.size());
+    assertTrue(diffBackups.contains(diff11));
+    assertTrue(diffBackups.contains(diff12));
+    assertTrue(diffBackups.contains(diff13));
+    assertTrue(diffBackups.contains(diff14));
 
     diffBackups = Utils.getReferencingDiffBackups(diff41);
-    Assert.assertEquals(0, diffBackups.size());
+    assertEquals(0, diffBackups.size());
   }
 
   @Test
   public void testGetBackups() {
     final List<String> backups = Utils.getBackupsAsDates(backupDir.getAbsoluteFile());
-    Assert.assertEquals(9, backups.size());
+    assertEquals(9, backups.size());
   }
 
   @Test
   public void testGetValidBackupSets() {
     final List<BackupSet> validBackupSets = Utils.getValidBackupSetsFromDirectories(backupDir);
-    Assert.assertEquals(3, validBackupSets.size());
+    assertEquals(3, validBackupSets.size());
   }
 
   @Test
@@ -158,19 +164,19 @@ public class TestUtils extends BackupDirStructureSetup {
     final Map<String, String> map = new HashMap<>();
     map.put("TEST_VAR", "REPLACEMENT");
     String path = "${TEST_VAR}";
-    Assert.assertEquals("REPLACEMENT", Utils.internalExpandEnvironmentVariables(path, map));
+    assertEquals("REPLACEMENT", Utils.internalExpandEnvironmentVariables(path, map));
     path = "1${TEST_VAR}2";
-    Assert.assertEquals("1REPLACEMENT2", Utils.internalExpandEnvironmentVariables(path, map));
+    assertEquals("1REPLACEMENT2", Utils.internalExpandEnvironmentVariables(path, map));
     path = "1${TEST_VAR2";
-    Assert.assertEquals("1${TEST_VAR2", Utils.internalExpandEnvironmentVariables(path, map));
+    assertEquals("1${TEST_VAR2", Utils.internalExpandEnvironmentVariables(path, map));
     path = "1${TEST_VAR}2${3";
-    Assert.assertEquals("1REPLACEMENT2${3", Utils.internalExpandEnvironmentVariables(path, map));
+    assertEquals("1REPLACEMENT2${3", Utils.internalExpandEnvironmentVariables(path, map));
     path = "1${TEST_VAR}2${TEST_VAR}3";
-    Assert.assertEquals("1REPLACEMENT2REPLACEMENT3", Utils.internalExpandEnvironmentVariables(path, map));
+    assertEquals("1REPLACEMENT2REPLACEMENT3", Utils.internalExpandEnvironmentVariables(path, map));
     path = "1${NO_VALUE_DEFINED}";
     try {
       Utils.internalExpandEnvironmentVariables(path, map);
-      Assert.fail("Expected an exception.");
+      fail("Expected an exception.");
     } catch (final EnvironmentVariableNotDefinedException evnde) {
       // if an exception is caught, everything is AOK.
     }


### PR DESCRIPTION
This PR migrates all tests to jUnit5. Some were test cases were already using jUnit5.

Most significant changes:

- Most `@Rule` was replaced by junit5's `@TempDir`, mostly for temporary folders
- `@Before` and `@After` were replaced by junit5's `@BeforeEach` and `@AfterEach`
- Usage of static imports to not have to call the classes for asserts
- Optimize all imports again
