### PR TITLE
touch file when backup successfully complete

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -84,6 +84,7 @@ public class HudsonBackup {
     public static final String CHANGELOG_HISTORY_PLUGIN_DIR_NAME = "changelog-history";
     public static final String SVN_CREDENTIALS_FILE_NAME = "subversion.credentials";
     public static final String SVN_EXTERNALS_FILE_NAME = "svnexternals.txt";
+    public static final String COMPLETED_BACKUP_FILE = "backup-completed.info";
 
     private final ThinBackupPluginImpl plugin;
     private final File hudsonHome;
@@ -222,6 +223,17 @@ public class HudsonBackup {
             moveOldBackupsToZipFile(backupDirectory);
             removeSuperfluousBackupSets();
         }
+        touchCompleteFile();
+    }
+
+    /**
+     * Creates a empty file backup-completed.info at the end of the backup.
+     *
+     * @throws IOException if an I/O Error occurs
+     */
+    public void touchCompleteFile() throws IOException {
+        File backupCompletedFile = new File(backupDirectory.getAbsolutePath(), COMPLETED_BACKUP_FILE);
+        backupCompletedFile.createNewFile();
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/backup/HudsonBackup.java
@@ -233,7 +233,7 @@ public class HudsonBackup {
      */
     public void touchCompleteFile() throws IOException {
         File backupCompletedFile = new File(backupDirectory.getAbsolutePath(), COMPLETED_BACKUP_FILE);
-        backupCompletedFile.createNewFile();
+        FileUtils.touch(backupCompletedFile);
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/restore/HudsonRestore.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/restore/HudsonRestore.java
@@ -58,6 +58,7 @@ public class HudsonRestore {
     private static final int SLEEP_TIMEOUT = 500;
 
     private static final Logger LOGGER = Logger.getLogger("hudson.plugins.thinbackup");
+    public static final String COMPLETED_BACKUP_FILE = "backup-completed.info";
 
     private final String backupPath;
     private final File hudsonHome;
@@ -164,10 +165,11 @@ public class HudsonRestore {
 
     private void restore(final File toRestore) throws IOException {
         final IOFileFilter nextBuildNumberFileFilter = FileFilterUtils.nameFileFilter("nextBuildNumber");
+        final IOFileFilter noBackupCompletedFile = FileFilterUtils.notFileFilter(FileFilterUtils.nameFileFilter(COMPLETED_BACKUP_FILE));
         IOFileFilter restoreNextBuildNumberFilter;
 
         if (restoreNextBuildNumber) {
-            restoreNextBuildNumberFilter = FileFilterUtils.trueFileFilter();
+            restoreNextBuildNumberFilter = noBackupCompletedFile;
 
             final Collection<File> restore =
                     FileUtils.listFiles(toRestore, nextBuildNumberFileFilter, TrueFileFilter.INSTANCE);
@@ -191,7 +193,10 @@ public class HudsonRestore {
                 }
             }
         } else {
-            restoreNextBuildNumberFilter = FileFilterUtils.notFileFilter(nextBuildNumberFileFilter);
+            restoreNextBuildNumberFilter = FileFilterUtils.andFileFilter(
+                FileFilterUtils.notFileFilter(nextBuildNumberFileFilter),
+                noBackupCompletedFile
+            );
         }
 
         FileUtils.copyDirectory(toRestore, this.hudsonHome, restoreNextBuildNumberFilter, true);

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/restore/HudsonRestore.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/restore/HudsonRestore.java
@@ -165,7 +165,8 @@ public class HudsonRestore {
 
     private void restore(final File toRestore) throws IOException {
         final IOFileFilter nextBuildNumberFileFilter = FileFilterUtils.nameFileFilter("nextBuildNumber");
-        final IOFileFilter noBackupCompletedFile = FileFilterUtils.notFileFilter(FileFilterUtils.nameFileFilter(COMPLETED_BACKUP_FILE));
+        final IOFileFilter noBackupCompletedFile =
+                FileFilterUtils.notFileFilter(FileFilterUtils.nameFileFilter(COMPLETED_BACKUP_FILE));
         IOFileFilter restoreNextBuildNumberFilter;
 
         if (restoreNextBuildNumber) {
@@ -194,9 +195,7 @@ public class HudsonRestore {
             }
         } else {
             restoreNextBuildNumberFilter = FileFilterUtils.andFileFilter(
-                FileFilterUtils.notFileFilter(nextBuildNumberFileFilter),
-                noBackupCompletedFile
-            );
+                    FileFilterUtils.notFileFilter(nextBuildNumberFileFilter), noBackupCompletedFile);
         }
 
         FileUtils.copyDirectory(toRestore, this.hudsonHome, restoreNextBuildNumberFilter, true);

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupZipping.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupZipping.java
@@ -108,7 +108,7 @@ public class TestBackupZipping {
             zipEntries.nextElement();
             ++entryCount;
         }
-        assertEquals(25, entryCount);
+        assertEquals(27, entryCount);
         zipFile.close();
 
         final BackupSet backupSetFromZip = new BackupSet(zippedBackupSet);


### PR DESCRIPTION
We would like to monitor when the backup completes so that we can archive it on an offline object store like S3.
Alternative considered:
- expose an endpoint to poll, however requires refactoring because we should save the "success" info somewhere.

### Testing done
N/A
