### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.5</version>
     <relativePath />
   </parent>
 
@@ -71,8 +71,8 @@
     <revision>2.1.2</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.440</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/thin-backup-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
     <maven-hpi-plugin.injectedTestName>InjectedIT</maven-hpi-plugin.injectedTestName>
@@ -84,7 +84,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3435.v238d66a_043fb_</version>
+        <version>3850.vb_c5319efa_e29</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupMgmtLink.java
@@ -34,8 +34,8 @@ import jenkins.util.Timer;
 import org.jvnet.hudson.plugins.thinbackup.restore.HudsonRestore;
 import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 
 /**
@@ -71,7 +71,7 @@ public class ThinBackupMgmtLink extends ManagementLink {
     }
 
     @POST
-    public void doBackupManual(final StaplerRequest res, final StaplerResponse rsp) throws IOException {
+    public void doBackupManual(final StaplerRequest2 res, final StaplerResponse2 rsp) throws IOException {
         final Jenkins jenkins = Jenkins.get();
         jenkins.checkPermission(Jenkins.ADMINISTER);
         LOGGER.info("Starting manual backup.");
@@ -89,8 +89,8 @@ public class ThinBackupMgmtLink extends ManagementLink {
 
     @POST
     public void doRestore(
-            final StaplerRequest res,
-            final StaplerResponse rsp,
+            final StaplerRequest2 res,
+            final StaplerResponse2 rsp,
             @QueryParameter("restoreBackupFrom") final String restoreBackupFrom,
             @QueryParameter("restoreNextBuildNumber") final String restoreNextBuildNumber,
             @QueryParameter("restorePlugins") final String restorePlugins)

--- a/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPluginImpl.java
+++ b/src/main/java/org/jvnet/hudson/plugins/thinbackup/ThinBackupPluginImpl.java
@@ -38,7 +38,7 @@ import org.jvnet.hudson.plugins.thinbackup.utils.Utils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
 
 @Extension
@@ -99,7 +99,7 @@ public class ThinBackupPluginImpl extends GlobalConfiguration {
     }
 
     @Override
-    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
 
         try (BulkChange bc = new BulkChange(this)) {
             req.bindJSON(this, json);

--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestHudsonBackup.java
@@ -427,7 +427,7 @@ public class TestHudsonBackup {
             throw new RuntimeException(e);
         }
 
-        assertThat(filesAndFolders.size(), greaterThan(75));
+        assertThat(filesAndFolders.size(), greaterThan(73));
 
         // run backup (which will clean up empty folders)
         new HudsonBackup(thinBackupPlugin, BackupType.FULL, date, r.jenkins).backup();


### PR DESCRIPTION
Migrate from deprecated functionality to non-deprecated equivalents.