### PR TITLE
Remove the `builds` folder assertion as it is no more created after RunIdMigrator removal

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupWithCloudBeesFolder.java
+++ b/src/test/java/org/jvnet/hudson/plugins/thinbackup/backup/TestBackupWithCloudBeesFolder.java
@@ -80,6 +80,6 @@ class TestBackupWithCloudBeesFolder {
         // check job is in folder
         File folderJobDir = new File(elementBackup, "jobs/elements");
         final List<String> listedJobElements = List.of(folderJobDir.list());
-        assertThat(listedJobElements, containsInAnyOrder("config.xml", "builds"));
+        assertThat(listedJobElements, containsInAnyOrder("config.xml"));
     }
 }


### PR DESCRIPTION
The test `TestBackupWithCloudBeesFolder` is failing after the `RunIdMigrator` removal in https://github.com/jenkinsci/jenkins/pull/10521. It was reported via https://github.com/jenkinsci/jenkins/pull/10517.

Now fixing the test to unblock https://github.com/jenkinsci/jenkins/pull/10521

**Reason for failure** 

Test is asserting if there is a `builds` folder existing in the backup or not. However note that the job doesn't even have a single build. Previously when the `RunIdMigrator` was there, it used to walk through the jobs and would create a marker file `legacyIds` if job was of type Freestyle or WorkflowJob which is buildable.

Now that `RunIdMigrator` is removed the `builds` will be created if the job was run at least once.


### Testing done

* reproduced the test with using the incremental release after (https://github.com/jenkinsci/jenkins/pull/10521), verified it works after the fix
  ```bash
  mvn -Dmaven.surefire.debug test \
  -Djenkins.version=2.505-rc36606.6430fb_c214b_d \
  -Dtest=TestBackupWithCloudBeesFolder#testWithFolder
  ```

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
